### PR TITLE
サーバー時間を基準にイベント処理を修正し、時間のずれによる問題を解消

### DIFF
--- a/scapi/cloud/cloud_event.py
+++ b/scapi/cloud/cloud_event.py
@@ -57,10 +57,13 @@ class CloudLogEvent(_base._BaseEvent):
         super().__init__(interval)
         self.project_id:int = project_id
         self.ClientSession:common.ClientSession = common.create_ClientSession(ClientSession)
-        self.lastest_dt = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.lastest_dt:datetime.datetime = 0
         self.Session:"session.Session|None" = None
 
     async def _event_monitoring(self):
+        logs = [log async for log in self._get_logs(limit=1)]
+        if logs:  # ログが存在する場合のみ処理
+            self.lastest_dt = logs[0].datetime
         self._call_event("on_ready")
         while self._running:
             try:

--- a/scapi/cloud/cloud_event.py
+++ b/scapi/cloud/cloud_event.py
@@ -57,7 +57,7 @@ class CloudLogEvent(_base._BaseEvent):
         super().__init__(interval)
         self.project_id:int = project_id
         self.ClientSession:common.ClientSession = common.create_ClientSession(ClientSession)
-        self.lastest_dt:datetime.datetime = 0
+        self.lastest_dt:datetime.datetime = None
         self.Session:"session.Session|None" = None
 
     async def _event_monitoring(self):

--- a/scapi/cloud/cloud_event.py
+++ b/scapi/cloud/cloud_event.py
@@ -57,7 +57,7 @@ class CloudLogEvent(_base._BaseEvent):
         super().__init__(interval)
         self.project_id:int = project_id
         self.ClientSession:common.ClientSession = common.create_ClientSession(ClientSession)
-        self.lastest_dt:datetime.datetime = None
+        self.lastest_dt:datetime.datetime = datetime.datetime(2000, 1, 1)
         self.Session:"session.Session|None" = None
 
     async def _event_monitoring(self):

--- a/scapi/cloud/cloud_event.py
+++ b/scapi/cloud/cloud_event.py
@@ -57,7 +57,7 @@ class CloudLogEvent(_base._BaseEvent):
         super().__init__(interval)
         self.project_id:int = project_id
         self.ClientSession:common.ClientSession = common.create_ClientSession(ClientSession)
-        self.lastest_dt:datetime.datetime = datetime.datetime(2000, 1, 1)
+        self.lastest_dt:datetime.datetime  = datetime.datetime(2000,1,1,tzinfo=datetime.timezone.utc)
         self.Session:"session.Session|None" = None
 
     async def _event_monitoring(self):

--- a/scapi/event/comment.py
+++ b/scapi/event/comment.py
@@ -15,10 +15,13 @@ class CommentEvent(_base._BaseEvent):
 
     def __init__(self,place:project.Project|studio.Studio|user.User,interval):
         self.place = place
-        self.lastest_comment_dt = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.lastest_comment_dt:datetime.datetime = 0
         super().__init__(interval)
 
     async def _event_monitoring(self):
+        comments = [comment async for comment in self.place.get_comments()]
+        if comments:  # コメントが存在する場合のみ処理
+            self.lastest_comment_dt = comments[0].sent_dt
         self._call_event("on_ready")
         while self._running:
             try:

--- a/scapi/event/comment.py
+++ b/scapi/event/comment.py
@@ -15,7 +15,7 @@ class CommentEvent(_base._BaseEvent):
 
     def __init__(self,place:project.Project|studio.Studio|user.User,interval):
         self.place = place
-        self.lastest_comment_dt:datetime.datetime = None
+        self.lastest_comment_dt:datetime.datetime = datetime.datetime(2000,1,1,tzinfo=datetime.timezone.utc)
         super().__init__(interval)
 
     async def _event_monitoring(self):

--- a/scapi/event/comment.py
+++ b/scapi/event/comment.py
@@ -15,7 +15,7 @@ class CommentEvent(_base._BaseEvent):
 
     def __init__(self,place:project.Project|studio.Studio|user.User,interval):
         self.place = place
-        self.lastest_comment_dt:datetime.datetime = 0
+        self.lastest_comment_dt:datetime.datetime = None
         super().__init__(interval)
 
     async def _event_monitoring(self):

--- a/scapi/event/message.py
+++ b/scapi/event/message.py
@@ -40,7 +40,7 @@ class SessionMessageEvent(_base._BaseEvent):
 
     def __init__(self,sessions:"Session",interval):
         self.session:"Session" = sessions
-        self.lastest_dt:datetime.datetime = 0
+        self.lastest_dt:datetime.datetime = None
         super().__init__(interval)
 
     async def _event_monitoring(self):

--- a/scapi/event/message.py
+++ b/scapi/event/message.py
@@ -40,7 +40,7 @@ class SessionMessageEvent(_base._BaseEvent):
 
     def __init__(self,sessions:"Session",interval):
         self.session:"Session" = sessions
-        self.lastest_dt:datetime.datetime = None
+        self.lastest_dt:datetime.datetime = datetime.datetime(2000,1,1,tzinfo=datetime.timezone.utc)
         super().__init__(interval)
 
     async def _event_monitoring(self):

--- a/scapi/event/message.py
+++ b/scapi/event/message.py
@@ -39,8 +39,8 @@ class SessionMessageEvent(_base._BaseEvent):
         return f"<SessionMessageEvent session:{self.session} running:{self._running} event:{self._event.keys()}>"
 
     def __init__(self,sessions:"Session",interval):
-        self.session: "Session" = sessions
-        self.lastest_dt: datetime.datetime = 0
+        self.session:"Session" = sessions
+        self.lastest_dt:datetime.datetime = 0
         super().__init__(interval)
 
     async def _event_monitoring(self):

--- a/scapi/event/message.py
+++ b/scapi/event/message.py
@@ -38,7 +38,7 @@ class SessionMessageEvent(_base._BaseEvent):
     def __str__(self) -> str:
         return f"<SessionMessageEvent session:{self.session} running:{self._running} event:{self._event.keys()}>"
 
-    def __init__(self, sessions: "Session", interval):
+    def __init__(self,sessions:"Session",interval):
         self.session: "Session" = sessions
         self.lastest_dt: datetime.datetime = 0
         super().__init__(interval)
@@ -58,8 +58,8 @@ class SessionMessageEvent(_base._BaseEvent):
                         continue
                     if i.datetime > self.lastest_dt:
                         temp_lastest_dt = i.datetime
-                        self._call_event("on_activity", i)
+                        self._call_event("on_activity",i)
                 self.lastest_dt = temp_lastest_dt
             except Exception as e:
-                self._call_event("on_error", e)
+                self._call_event("on_error",e)
             await asyncio.sleep(self.interval)

--- a/scapi/event/message.py
+++ b/scapi/event/message.py
@@ -38,12 +38,15 @@ class SessionMessageEvent(_base._BaseEvent):
     def __str__(self) -> str:
         return f"<SessionMessageEvent session:{self.session} running:{self._running} event:{self._event.keys()}>"
 
-    def __init__(self,sessions:"Session",interval):
-        self.session:"Session" = sessions
-        self.lastest_dt:datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc)
+    def __init__(self, sessions: "Session", interval):
+        self.session: "Session" = sessions
+        self.lastest_dt: datetime.datetime = 0
         super().__init__(interval)
 
     async def _event_monitoring(self):
+        messages = [message async for message in self.session.message()]
+        if messages:
+            self.lastest_dt = messages[0].datetime
         self._call_event("on_ready")
         while self._running:
             try:
@@ -55,8 +58,8 @@ class SessionMessageEvent(_base._BaseEvent):
                         continue
                     if i.datetime > self.lastest_dt:
                         temp_lastest_dt = i.datetime
-                        self._call_event("on_activity",i)
+                        self._call_event("on_activity", i)
                 self.lastest_dt = temp_lastest_dt
             except Exception as e:
-                self._call_event("on_error",e)
+                self._call_event("on_error", e)
             await asyncio.sleep(self.interval)


### PR DESCRIPTION
⚠これは #28 のbase先を変更したコピーです⚠
### 修正内容
PCの時間とScratchサーバーの時間がずれている場合にイベントが正しく動作しない問題を解消するため、サーバー時間を基準にイベント処理を行うように修正しました。

#### 修正箇所
1. **`message.py`**
   - `SessionMessageEvent._event_monitoring` メソッドで、サーバー時間を基準に`datetime`の比較を行うように修正しました。

2. **`cloud_event.py`**
   - `CloudLogEvent._event_monitoring` メソッドで、サーバー時間を基準に`datetime`の比較を行うように修正しました。

3. **`comment.py`**
   - `CommentEvent._event_monitoring` メソッドで、サーバー時間を基準に`datetime`の比較を行うように修正しました。

#### 修正のポイント
- `datetime.datetime.min` を初期値として設定し、サーバー時間を基準に比較を行うことで、PCの時間とサーバー時間のずれによる問題を解消しました。
- サーバーから取得した`datetime`を基準にイベント処理を行うように変更しました。

#### テスト
- PCの時間を意図的にずらしてテストを実行しました。
- サーバー時間を基準にイベントが正しく動作することを確認しました。

#### 影響範囲
- `SessionMessageEvent` クラス
- `CloudLogEvent` クラス
- `CommentEvent` クラス

### チェックリスト
- [ ] サーバー時間を基準に比較する処理を追加
- [ ] 動作確認済み（PCの時間をずらしてテスト）
- [ ] エラーハンドリングの維持

Closed #26