### PR TITLE
CloudイベントリスナーのLog/Websocketの自動判断機能の追加

### DIFF
--- a/scapi/__init__.py
+++ b/scapi/__init__.py
@@ -111,7 +111,7 @@ from .cloud.cloud import (
     ScratchCloud
 )
 from .cloud.cloud_event import (
-    CloudEvent,
+    CloudWebsocketEvent,
     CloudLogEvent,
 )
 from .cloud.server import (

--- a/scapi/cloud/cloud_event.py
+++ b/scapi/cloud/cloud_event.py
@@ -30,9 +30,9 @@ async def _on_disconnect(_self:"cloud._BaseCloud",interval:int):
     _self._event._call_event(f"on_disconnect",interval)
 
 
-class CloudEvent(_base._BaseEvent):
+class CloudWebsocketEvent(_base._BaseEvent):
     def __str__(self) -> str:
-        return f"<CloudEvent cloud:{self.cloud} running:{self._running} event:{self._event.keys()}>"
+        return f"<CloudWebsocketEvent cloud:{self.cloud} running:{self._running} event:{self._event.keys()}>"
 
     def __init__(self,cloud_obj:cloud._BaseCloud):
         super().__init__(0)


### PR DESCRIPTION
### 新規機能
- Cloudイベントリスナーにmode引数を追加し、自動選択（auto）機能を実装。
- log_interval引数を追加し、Logモードでのポーリング間隔を設定可能に。

### 変更内容:
- LogとWebSocketの自動選択ロジックを実装。
- モード別の動作（auto/websocket/log）をテストでカバー。
